### PR TITLE
feat: added UI open on open

### DIFF
--- a/llmstudio/models/models.py
+++ b/llmstudio/models/models.py
@@ -1,14 +1,14 @@
 import asyncio
+import time
 from abc import ABC, abstractmethod
 from statistics import mean
-import time
 
 import nest_asyncio
 import numpy as np
 import requests
-from requests.exceptions import RequestException
 from aiohttp import ClientSession
 from pydantic import BaseModel
+from requests.exceptions import RequestException
 from sentence_transformers import SentenceTransformer, util
 
 from llmstudio.engine.config import EngineConfig, RouteType
@@ -87,11 +87,13 @@ class LLMModel(ABC):
                 if not response.json():
                     raise ValueError(f"The API key doesn't have access to {self.model_name}")
                 return  # Successful API check
-            except RequestException as e:
+            except RequestException:
                 retries += 1
                 time.sleep(delay)  # Wait before retrying
-                
-        raise ValueError("Max retries reached. The API key doesn't have access to {self.model_name}")
+
+        raise ValueError(
+            "Max retries reached. The API key doesn't have access to {self.model_name}"
+        )
 
     @abstractmethod
     def validate_parameters(self, parameters: BaseModel) -> BaseModel:

--- a/llmstudio/utils/rest_utils.py
+++ b/llmstudio/utils/rest_utils.py
@@ -1,3 +1,4 @@
+import webbrowser
 from threading import Thread
 
 import requests
@@ -29,11 +30,13 @@ def run_engine_app(engine_config=EngineConfig()):
     )
 
 
-def run_ui_app(ui_server_app):
+def run_ui_app(ui_server_app, api_name="UI", host="localhost", port=3000):
+    print(f"Running {api_name} on {host}:{port}")
+    webbrowser.open(f"http://{host}:{port}")
     uvicorn.run(
         ui_server_app,
-        host="localhost",
-        port=3000,
+        host=host,
+        port=port,
         log_level="critical",
     )
 


### PR DESCRIPTION
Running `llmstudio server` now gives a message saying the UI is running at port X + opens a browser at said port