### PR TITLE
Feat/params on init

### DIFF
--- a/llmstudio/__init__.py
+++ b/llmstudio/__init__.py
@@ -1,5 +1,5 @@
 name = "version"
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 __requirements__ = [
     "pydantic",

--- a/llmstudio/models/__init__.py
+++ b/llmstudio/models/__init__.py
@@ -1,4 +1,4 @@
 from .bedrock import BedrockClient
-from .models import LLMClient, LLMModel, LLMCompare
+from .models import LLMClient, LLMCompare, LLMModel
 from .openai import OpenAIClient
 from .vertexai import VertexAIClient

--- a/llmstudio/models/models.py
+++ b/llmstudio/models/models.py
@@ -44,7 +44,7 @@ class LLMModel(ABC):
         api_region: str = None,
         tests: dict = {},
         engine_config: EngineConfig = EngineConfig(),
-        parameters: BaseModel = None
+        parameters: BaseModel = None,
     ):
         """
         Initialize the LLMModel instance.
@@ -110,7 +110,14 @@ class LLMModel(ABC):
             BaseModel: Validated/adjusted parameters encapsulated in a Pydantic model.
         """
 
-    def chat(self, chat_input: str, parameters: BaseModel = None, is_stream: bool = False,safety_margin = None, custom_max_tokens = None):
+    def chat(
+        self,
+        chat_input: str,
+        parameters: BaseModel = None,
+        is_stream: bool = False,
+        safety_margin=None,
+        custom_max_tokens=None,
+    ):
         """
         Initiate a chat interaction with the language model.
 
@@ -149,7 +156,7 @@ class LLMModel(ABC):
                 "parameters": parameters,
                 "is_stream": is_stream,
                 "safety_margin": safety_margin,
-                "custom_max_token": custom_max_tokens
+                "custom_max_token": custom_max_tokens,
             },
             headers={"Content-Type": "application/json"},
             timeout=30,
@@ -314,7 +321,7 @@ class LLMClient(ABC):
             api_secret=self.api_secret,
             api_region=self.api_region,
             engine_config=self.engine_config,
-            parameters=parameters
+            parameters=parameters,
         )
 
 

--- a/llmstudio/models/models.py
+++ b/llmstudio/models/models.py
@@ -44,6 +44,7 @@ class LLMModel(ABC):
         api_region: str = None,
         tests: dict = {},
         engine_config: EngineConfig = EngineConfig(),
+        parameters: BaseModel = None
     ):
         """
         Initialize the LLMModel instance.
@@ -64,6 +65,8 @@ class LLMModel(ABC):
         self.chat_url = (
             f"{str(engine_config.routes_endpoint)}/{RouteType.LLM_CHAT.value}/{self.PROVIDER}"
         )
+        validated_params = self.validate_parameters(parameters)
+        self.parameters = validated_params
 
     @staticmethod
     def _raise_api_key_error():
@@ -120,7 +123,7 @@ class LLMModel(ABC):
                           that you want the model to respond to.
             parameters (BaseModel, optional): A Pydantic model containing parameters that affect
                                           the model's responses, such as "temperature" or
-                                          "max tokens". Defaults to None.
+                                          "max tokens". Defaults to None. If no parameters are specified the ones declared when instancianting the model will be used if available.
             is_stream (bool, optional): A boolean flag that indicates whether the request should
                                     be handled as a stream. Defaults to False.
 
@@ -131,7 +134,10 @@ class LLMModel(ABC):
             RequestException: If the API request fails.
             ValueError: If the API response cannot be parsed or contains error information.
         """
-        validated_params = self.validate_parameters(parameters)
+        if not parameters:
+            parameters = self.parameters
+        else:
+            parameters = self.validate_parameters(parameters)
         response = requests.post(
             self.chat_url,
             json={
@@ -140,7 +146,7 @@ class LLMModel(ABC):
                 "api_secret": self.api_secret,
                 "api_region": self.api_region,
                 "chat_input": chat_input,
-                "parameters": validated_params,
+                "parameters": parameters,
                 "is_stream": is_stream,
                 "safety_margin": safety_margin,
                 "custom_max_token": custom_max_tokens
@@ -156,6 +162,10 @@ class LLMModel(ABC):
         self, chat_input: str, parameters: BaseModel = None, is_stream: bool = False
     ):
         async with ClientSession() as session:
+            if not parameters:
+                parameters = self.parameters
+            else:
+                parameters = self.validate_parameters(parameters)
             async with session.post(
                 self.chat_url,
                 json={
@@ -236,25 +246,6 @@ class LLMModel(ABC):
                 raise ValueError(f"question and answer should be strings")
         return tests
 
-    # Sequential code for running tests
-    """
-    def run_tests(self, tests: dict = {}, parameters: dict = {}, is_stream: bool = False):
-
-        if not tests:
-            tests = self.tests
-
-        tests = self.validate_tests(tests)
-
-        test_responses = {}
-        for key in tests:
-            test, gt_answer = tests[key].values()
-            print(f"Key: {key} / Test: {test} / GT Answer: {gt_answer}")
-            response = self.chat(test,parameters=parameters,is_stream=is_stream)
-            test_responses[key] = response
-
-        return test_responses
-    """
-
 
 class LLMClient(ABC):
     """
@@ -297,7 +288,7 @@ class LLMClient(ABC):
         self.engine_config = engine_config
         run_apis(engine_config=self.engine_config)
 
-    def get_model(self, model_name: str):
+    def get_model(self, model_name: str, parameters: BaseModel = None):
         """
         Retrieve an instance of an LLM model by name.
 
@@ -323,6 +314,7 @@ class LLMClient(ABC):
             api_secret=self.api_secret,
             api_region=self.api_region,
             engine_config=self.engine_config,
+            parameters=parameters
         )
 
 

--- a/llmstudio/models/openai.py
+++ b/llmstudio/models/openai.py
@@ -53,12 +53,18 @@ class OpenAIClient(LLMClient):
 
         PROVIDER = "openai"
 
-        def __init__(self, model_name: str, api_key: str, engine_config: EngineConfig, parameters: OpenAIParameters = None):
+        def __init__(
+            self,
+            model_name: str,
+            api_key: str,
+            engine_config: EngineConfig,
+            parameters: OpenAIParameters = None,
+        ):
             super().__init__(
                 model_name,
                 api_key or os.environ.get("OPENAI_API_KEY") or self._raise_api_key_error(),
                 engine_config=engine_config,
-                parameters=parameters
+                parameters=parameters,
             )
             self._check_api_access()
 
@@ -83,12 +89,19 @@ class OpenAIClient(LLMClient):
         'GPT-3.5-turbo' OpenAI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, parameters: OpenAIParameters, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: OpenAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
-                parameters=parameters
+                parameters=parameters,
             )
 
     class GPT4(OpenAIModel):
@@ -99,10 +112,17 @@ class OpenAIClient(LLMClient):
         with the 'GPT-4' OpenAI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, parameters: OpenAIParameters, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: OpenAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
-                parameters=parameters
+                parameters=parameters,
             )

--- a/llmstudio/models/openai.py
+++ b/llmstudio/models/openai.py
@@ -53,11 +53,12 @@ class OpenAIClient(LLMClient):
 
         PROVIDER = "openai"
 
-        def __init__(self, model_name: str, api_key: str, engine_config: EngineConfig):
+        def __init__(self, model_name: str, api_key: str, engine_config: EngineConfig, parameters: OpenAIParameters = None):
             super().__init__(
                 model_name,
                 api_key or os.environ.get("OPENAI_API_KEY") or self._raise_api_key_error(),
                 engine_config=engine_config,
+                parameters=parameters
             )
             self._check_api_access()
 
@@ -82,11 +83,12 @@ class OpenAIClient(LLMClient):
         'GPT-3.5-turbo' OpenAI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(self, model_name, api_key, engine_config: EngineConfig, parameters: OpenAIParameters, **kwargs):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters
             )
 
     class GPT4(OpenAIModel):
@@ -97,9 +99,10 @@ class OpenAIClient(LLMClient):
         with the 'GPT-4' OpenAI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(self, model_name, api_key, engine_config: EngineConfig, parameters: OpenAIParameters, **kwargs):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters
             )

--- a/llmstudio/models/vertexai.py
+++ b/llmstudio/models/vertexai.py
@@ -56,11 +56,18 @@ class VertexAIClient(LLMClient):
 
         PROVIDER = "vertexai"
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: VertexAIParameters = None,
+        ):
             super().__init__(
                 model_name,
                 api_key or self._raise_api_key_error(),
                 engine_config=engine_config,
+                parameters=parameters,
             )
             self._check_api_access()
 
@@ -85,11 +92,19 @@ class VertexAIClient(LLMClient):
         'TextBison' Vertex AI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: VertexAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters,
             )
 
     class ChatBison(VertexAIModel):
@@ -100,11 +115,19 @@ class VertexAIClient(LLMClient):
         with the 'ChatBison' Vertex AI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: VertexAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters,
             )
 
     class CodeBison(VertexAIModel):
@@ -115,11 +138,19 @@ class VertexAIClient(LLMClient):
         with the 'ChatBison' Vertex AI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: VertexAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters,
             )
 
     class CodeChatBison(VertexAIModel):
@@ -130,9 +161,17 @@ class VertexAIClient(LLMClient):
         with the 'ChatBison' Vertex AI LLM.
         """
 
-        def __init__(self, model_name, api_key, engine_config: EngineConfig, **kwargs):
+        def __init__(
+            self,
+            model_name,
+            api_key,
+            engine_config: EngineConfig,
+            parameters: VertexAIParameters,
+            **kwargs
+        ):
             super().__init__(
                 model_name=model_name,
                 api_key=api_key,
                 engine_config=engine_config,
+                parameters=parameters,
             )


### PR DESCRIPTION
Added feature from #40, however currently only supports OpenAI. Support for other providers should be trivial.
In summary the client.get_model now also takes in params. This was necessary for the integration with langchain.
If parameters are provided in the .chat function, they override the ones set in the get_model