### PR TITLE
[feat] added deployment names to response

### DIFF
--- a/llmstudio/engine/providers/provider.py
+++ b/llmstudio/engine/providers/provider.py
@@ -120,6 +120,7 @@ class Provider:
                     yield chunk.get("choices")[0].get("delta").get("content")
 
         chunks = [chunk[0] if isinstance(chunk, tuple) else chunk for chunk in chunks]
+        model = next(chunk["model"] for chunk in chunks if chunk.get("model"))
 
         response, output_string = self.join_chunks(chunks, request)
 
@@ -150,7 +151,16 @@ class Provider:
                 else request.chat_input
             ),
             "provider": self.config.id,
-            "model": request.model,
+            "model": (
+                request.model
+                if model and model.startswith(request.model)
+                else (model or request.model)
+            ),
+            "deployment": (
+                model
+                if model and model.startswith(request.model)
+                else (request.model if model != request.model else None)
+            ),
             "timestamp": time.time(),
             "parameters": request.parameters.model_dump(),
             "metrics": metrics,

--- a/llmstudio/tracking/logs/models.py
+++ b/llmstudio/tracking/logs/models.py
@@ -17,5 +17,6 @@ class LogDefault(Base):
     context = Column(JSON)
     provider = Column(String)
     model = Column(String)
+    deployment = Column(String)
     parameters = Column(JSON)
     metrics = Column(JSON)

--- a/llmstudio/tracking/logs/schemas.py
+++ b/llmstudio/tracking/logs/schemas.py
@@ -12,6 +12,7 @@ class LogDefaultBase(BaseModel):
     context: List[Dict[str, Any]] = None
     provider: str = None
     model: str = None
+    deployment: str = None
     parameters: dict = None
     metrics: dict = None
 


### PR DESCRIPTION
We now have a new deployment parameter on the response.

Custom names (Azure) or versioned names (OpenAI) will be placed on "deployment". Main model family will stay in "model".