### PR TITLE
[fix] Added event tracking for server startup 

### DIFF
--- a/llmstudio/engine/__init__.py
+++ b/llmstudio/engine/__init__.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from threading import Event
 from typing import Any, Dict, List, Optional, Union
 
 import uvicorn
@@ -9,7 +10,6 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ValidationError
-from threading import Event
 
 from llmstudio.config import ENGINE_HOST, ENGINE_PORT
 from llmstudio.engine.providers import *
@@ -79,7 +79,9 @@ def _load_engine_config() -> EngineConfig:
         raise RuntimeError(f"Error in configuration data: {e}")
 
 
-def create_engine_app(started_event: Event, config: EngineConfig = _load_engine_config()) -> FastAPI:
+def create_engine_app(
+    started_event: Event, config: EngineConfig = _load_engine_config()
+) -> FastAPI:
     app = FastAPI(
         title=ENGINE_TITLE,
         description=ENGINE_DESCRIPTION,
@@ -169,7 +171,7 @@ def create_engine_app(started_event: Event, config: EngineConfig = _load_engine_
     return app
 
 
-def run_engine_app(started_event : Event):
+def run_engine_app(started_event: Event):
     try:
         engine = create_engine_app(started_event)
         uvicorn.run(

--- a/llmstudio/engine/providers/azure.py
+++ b/llmstudio/engine/providers/azure.py
@@ -120,13 +120,17 @@ class AzureProvider(Provider):
                 **function_args,
                 **request.parameters.model_dump(),
             }
-
             # Perform the asynchronous call
             return await asyncio.to_thread(
                 client.chat.completions.create, **combined_args
             )
 
-        except openai._exceptions.APIError as e:
+        except openai._exceptions.APIConnectionError as e:
+            raise HTTPException(
+                status_code=404, detail="There was an error reaching the endpoint"
+            )
+
+        except openai._exceptions.APIStatusError as e:
             raise HTTPException(status_code=e.status_code, detail=e.response.json())
 
     def prepare_messages(self, request: AzureRequest):

--- a/llmstudio/engine/providers/azure.py
+++ b/llmstudio/engine/providers/azure.py
@@ -127,7 +127,7 @@ class AzureProvider(Provider):
 
         except openai._exceptions.APIConnectionError as e:
             raise HTTPException(
-                status_code=404, detail="There was an error reaching the endpoint"
+                status_code=404, detail=f"There was an error reaching the endpoint: {e}"
             )
 
         except openai._exceptions.APIStatusError as e:

--- a/llmstudio/llm/__init__.py
+++ b/llmstudio/llm/__init__.py
@@ -9,10 +9,11 @@ from llmstudio.config import ENGINE_HOST, ENGINE_PORT
 from llmstudio.llm.semaphore import DynamicSemaphore
 from llmstudio.server import start_server
 
+start_server()
+
 
 class LLM:
     def __init__(self, model_id: str, **kwargs):
-        start_server()
         self.provider, self.model = model_id.split("/")
         self.session_id = kwargs.get("session_id")
         self.api_key = kwargs.get("api_key")

--- a/llmstudio/llm/__init__.py
+++ b/llmstudio/llm/__init__.py
@@ -9,6 +9,7 @@ from llmstudio.config import ENGINE_HOST, ENGINE_PORT
 from llmstudio.llm.semaphore import DynamicSemaphore
 from llmstudio.server import start_server
 
+
 class LLM:
     def __init__(self, model_id: str, **kwargs):
         start_server()

--- a/llmstudio/llm/__init__.py
+++ b/llmstudio/llm/__init__.py
@@ -9,11 +9,9 @@ from llmstudio.config import ENGINE_HOST, ENGINE_PORT
 from llmstudio.llm.semaphore import DynamicSemaphore
 from llmstudio.server import start_server
 
-start_server()
-
-
 class LLM:
     def __init__(self, model_id: str, **kwargs):
+        start_server()
         self.provider, self.model = model_id.split("/")
         self.session_id = kwargs.get("session_id")
         self.api_key = kwargs.get("api_key")

--- a/llmstudio/server.py
+++ b/llmstudio/server.py
@@ -1,4 +1,5 @@
 import threading
+from threading import Event
 
 import requests
 
@@ -13,7 +14,6 @@ from llmstudio.config import (
 from llmstudio.engine import run_engine_app
 from llmstudio.tracking import run_tracking_app
 from llmstudio.ui import run_ui_app
-from threading import Event
 
 _servers_started = False
 
@@ -33,7 +33,7 @@ def start_server_component(host, port, run_func, server_name):
         started_event = Event()
         thread = threading.Thread(target=run_func, daemon=True, args=(started_event,))
         thread.start()
-        started_event.wait() # wait for startup, this assumes the event is set somewhere
+        started_event.wait()  # wait for startup, this assumes the event is set somewhere
         return thread
     else:
         print(f"{server_name} server already running on {host}:{port}")

--- a/llmstudio/tracking/__init__.py
+++ b/llmstudio/tracking/__init__.py
@@ -1,7 +1,8 @@
+from threading import Event
+
 import uvicorn
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from threading import Event
 
 from llmstudio.config import TRACKING_HOST, TRACKING_PORT
 from llmstudio.engine.providers import *
@@ -16,7 +17,7 @@ TRACKING_BASE_ENDPOINT = "/api/tracking"
 
 
 ## Tracking
-def create_tracking_app(started_event : Event) -> FastAPI:
+def create_tracking_app(started_event: Event) -> FastAPI:
     app = FastAPI(
         title=TRACKING_TITLE,
         description=TRACKING_DESCRIPTION,

--- a/llmstudio/tracking/__init__.py
+++ b/llmstudio/tracking/__init__.py
@@ -1,6 +1,7 @@
 import uvicorn
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from threading import Event
 
 from llmstudio.config import TRACKING_HOST, TRACKING_PORT
 from llmstudio.engine.providers import *
@@ -15,7 +16,7 @@ TRACKING_BASE_ENDPOINT = "/api/tracking"
 
 
 ## Tracking
-def create_tracking_app() -> FastAPI:
+def create_tracking_app(started_event : Event) -> FastAPI:
     app = FastAPI(
         title=TRACKING_TITLE,
         description=TRACKING_DESCRIPTION,
@@ -43,14 +44,15 @@ def create_tracking_app() -> FastAPI:
 
     @app.on_event("startup")
     async def startup_event():
+        started_event.set()
         print(f"Running LLMstudio Tracking on http://{TRACKING_HOST}:{TRACKING_PORT} ")
 
     return app
 
 
-def run_tracking_app():
+def run_tracking_app(started_event: Event):
     try:
-        tracking = create_tracking_app()
+        tracking = create_tracking_app(started_event)
         uvicorn.run(
             tracking,
             host=TRACKING_HOST,

--- a/llmstudio/ui/__init__.py
+++ b/llmstudio/ui/__init__.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 import threading
-import webbrowser
+from threading import Event
 
 from llmstudio.config import UI_PORT
 
@@ -20,6 +20,7 @@ def run_bun_in_thread():
         print(f"Error running LLMstudio UI: {e}")
 
 
-def run_ui_app():
+def run_ui_app(started_event: Event):
     thread = threading.Thread(target=run_bun_in_thread)
     thread.start()
+    started_event.set() #just here for compatibility


### PR DESCRIPTION
### What was done in this PR:
Added events to the startup process of tracking, ui and engine.
This removes the race conditions we were experiencing repeatedly, also removes the need to run `start_server()` as early as possible.
This works on an event-based architecture:
1. Every server startup function passed to `start_server_component` is passed an event. The responsability is of this function to, at some point, run event.set()
2. Using the `@app.on_event("startup")` callback mechanism, the event is set
3. The event is waited through `event.wait()`, this locks everything down until the server actually starts

### How it was tested:

Simple scripts that were failing before, can run further testing

### Additional notes:
Did not implement UI waiting, it runs event.set() without waiting, might want to add some actual on_start callbacks
Did not implement timeouts, it's very easy to do, but doesn't seem very necessary


- Any performance improvements?
It is no longer a russian roulette to run llmstudio