### PR TITLE
Fix deploy on GKE guide

### DIFF
--- a/docs/how-to/deploy-on-gke/deploy-on-google-kubernetes-engine.mdx
+++ b/docs/how-to/deploy-on-gke/deploy-on-google-kubernetes-engine.mdx
@@ -1,3 +1,7 @@
+---
+title: "Deploy on Google Kubernetes Engine"
+---
+
 Learn how to deploy LLMstudio as a containerized application on Google Kubernetes Engine and make calls from a local repository.
 
 

--- a/docs/how-to/deploy-on-gke/deploy-on-google-kubernetes-engine.mdx
+++ b/docs/how-to/deploy-on-gke/deploy-on-google-kubernetes-engine.mdx
@@ -18,20 +18,20 @@ This example demonstrates a public deployment. For a private service accessible 
   <Step title="Select Deploy">
     Go to **Workloads** and **Create a new Deployment**.
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-2.png" />
+      <img src="images/step-2.png" />
     </Frame>
   </Step>
   <Step title="Name Your Deployment">
     Rename your project. We will call the one in this guide **llmstudio-on-gcp**.
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-3.png" />
+      <img src="images/step-3.png" />
     </Frame>
   </Step>
   <Step title="Select Your Cluster">
     Choose between **creating a new cluster** or **using an existing cluster**. 
     For this guide, we will create a new cluster and use the default region.
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-4.png" />
+      <img src="images/step-4.png" />
     </Frame>
   </Step>
   <Step title="Proceed to Container Details">
@@ -47,7 +47,7 @@ This example demonstrates a public deployment. For a private service accessible 
     ```
     Set it as the **Image path** to your container.
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-6.png" />
+      <img src="images/step-6.png" />
     </Frame>
   </Step>
   <Step title="Set Environment Variables">
@@ -63,7 +63,7 @@ Additionally, set the `GOOGLE_API_KEY` environment variable to enable calls to G
 <Tip>Refer to **SDK/LLM/Providers** for instructions on setting up other providers.</Tip>
 
 <Frame>
-  <img src="how-to/deploy-on-gke/images/step-7.png" />
+  <img src="images/step-7.png" />
 </Frame>
 
   </Step>
@@ -74,13 +74,13 @@ Additionally, set the `GOOGLE_API_KEY` environment variable to enable calls to G
     Select **Expose deployment as a new service** and leave the first item as is.
 
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-9-1.png" />
+      <img src="images/step-9-1.png" />
     </Frame>
     
     Add two other items, and expose the ports defined in the **Set Environment Variables** step.
 
     <Frame>
-      <img src="how-to/deploy-on-gke/images/step-9-2.png" />
+      <img src="images/step-9-2.png" />
     </Frame>
   </Step>
   <Step title="Deploy">
@@ -108,7 +108,7 @@ Now let's make a call to our LLMstudio instance on GCP!
 
         Go to your newly deployed **Workload**, scroll to the **Exposing services** section, and take note of the Host of your endpoint.
         <Frame>
-          <img src="how-to/deploy-on-gke/images/step-env.png" />
+          <img src="images/step-env.png" />
         </Frame>
 
         Create your `.env` file with the following:
@@ -141,7 +141,7 @@ Now let's make a call to our LLMstudio instance on GCP!
         ```
 
         <Frame>
-          <img src="how-to/deploy-on-gke/images/step-llmstudio-call.png" />
+          <img src="images/step-llmstudio-call.png" />
         </Frame>
 
         


### PR DESCRIPTION
## LLMstudio Version 0.3.12

### What was done in this PR:

- Fixed image pathing for `how-to` `deploy-on-gke` guide.
- Fixed lettering for the title of `deploy-on-gke` guide.
