### PR TITLE
Feat/set url in server config

### DIFF
--- a/libs/proxy/llmstudio_proxy/provider.py
+++ b/libs/proxy/llmstudio_proxy/provider.py
@@ -26,19 +26,16 @@ class ProxyConfig(BaseModel):
                     "You must provide either both 'host' and 'port', or 'url'."
                 )
 
+
 class LLMProxyProvider(Provider):
     def __init__(self, provider: str, proxy_config: ProxyConfig):
         self.provider = provider
         self.engine_url = proxy_config.url
 
         if is_server_running(url=self.engine_url):
-            print(
-                f"Connected to LLMStudio Proxy @ {self.engine_url}"
-            )
+            print(f"Connected to LLMStudio Proxy @ {self.engine_url}")
         else:
-            raise Exception(
-                f"LLMStudio Proxy is not running @ {self.engine_url}"
-            )
+            raise Exception(f"LLMStudio Proxy is not running @ {self.engine_url}")
 
     @staticmethod
     def _provider_config_name():

--- a/libs/proxy/llmstudio_proxy/server.py
+++ b/libs/proxy/llmstudio_proxy/server.py
@@ -165,9 +165,9 @@ def run_proxy_app(started_event: Event):
         print(f"Error running LLMstudio Proxy: {e}")
 
 
-def is_server_running(host, port, path="/health"):
+def is_server_running(url, path="/health"):
     try:
-        response = requests.get(f"http://{host}:{port}{path}")
+        response = requests.get(f"{url}{path}")
         if response.status_code == 200 and response.json().get("status") == "healthy":
             return True
     except requests.ConnectionError:
@@ -176,7 +176,7 @@ def is_server_running(host, port, path="/health"):
 
 
 def start_server_component(host, port, run_func, server_name):
-    if not is_server_running(host, port):
+    if not is_server_running(url=f"http://{host}:{port}"):
         started_event = Event()
         thread = Thread(target=run_func, daemon=True, args=(started_event,))
         thread.start()

--- a/libs/tracker/llmstudio_tracker/server.py
+++ b/libs/tracker/llmstudio_tracker/server.py
@@ -66,9 +66,9 @@ def run_tracker_app(started_event: Event):
         print(f"Error running LLMstudio Tracking: {e}")
 
 
-def is_server_running(host, port, path="/health"):
+def is_server_running(url, path="/health"):
     try:
-        response = requests.get(f"http://{host}:{port}{path}")
+        response = requests.get(f"{url}{path}")
         if response.status_code == 200 and response.json().get("status") == "healthy":
             return True
     except requests.ConnectionError:
@@ -77,7 +77,7 @@ def is_server_running(host, port, path="/health"):
 
 
 def start_server_component(host, port, run_func, server_name):
-    if not is_server_running(host, port):
+    if not is_server_running(url=f"http://{host}:{port}"):
         started_event = Event()
         thread = Thread(target=run_func, daemon=True, args=(started_event,))
         thread.start()

--- a/libs/tracker/llmstudio_tracker/tracker.py
+++ b/libs/tracker/llmstudio_tracker/tracker.py
@@ -15,7 +15,7 @@ class TrackingConfig(BaseModel):
         super().__init__(**data)
         if self.url is None:
             if self.host is not None and self.port is not None:
-                self.url = f"{self.host}:{self.port}"
+                self.url = f"http://{self.host}:{self.port}"
             else:
                 raise ValueError(
                     "You must provide either both 'host' and 'port', or 'url'."
@@ -29,7 +29,7 @@ class Tracker:
 
     def log(self, data: dict):
         req = self._session.post(
-            f"https://{self.tracking_url}/api/tracking/logs",
+            f"{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -38,7 +38,7 @@ class Tracker:
 
     def get_logs(self):
         req = self._session.get(
-            f"https://{self.tracking_url}/api/tracking/logs",
+            f"{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -46,7 +46,7 @@ class Tracker:
 
     def get_session_logs(self, session_id: str):
         req = self._session.get(
-            f"https://{self.tracking_url}/api/tracking/logs/{session_id}",
+            f"{self.tracking_url}/api/tracking/logs/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -54,7 +54,7 @@ class Tracker:
 
     def update_session(self, data: dict):
         req = self._session.post(
-            f"https://{self.tracking_url}/api/tracking/session",
+            f"{self.tracking_url}/api/tracking/session",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -63,7 +63,7 @@ class Tracker:
 
     def get_session(self, session_id: str):
         req = self._session.get(
-            f"https://{self.tracking_url}/api/tracking/session/{session_id}",
+            f"{self.tracking_url}/api/tracking/session/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -71,7 +71,7 @@ class Tracker:
 
     def add_extras(self, message_id: int):
         req = self._session.patch(
-            f"https://{self.tracking_url}/api/tracking/session/{message_id}",
+            f"{self.tracking_url}/api/tracking/session/{message_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )

--- a/libs/tracker/llmstudio_tracker/tracker.py
+++ b/libs/tracker/llmstudio_tracker/tracker.py
@@ -13,21 +13,23 @@ class TrackingConfig(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if (self.host is None and self.port is None) and self.url is None:
-            raise ValueError(
-                "You must provide either both 'host' and 'port', or 'url', or 'database_uri'."
-            )
+        if self.url is None:
+            if self.host is not None and self.port is not None:
+                self.url = f"{self.host}:{self.port}"
+            else:
+                raise ValueError(
+                    "You must provide either both 'host' and 'port', or 'url'."
+                )
 
 
 class Tracker:
     def __init__(self, tracking_config: TrackingConfig):
-        self.tracking_host = tracking_config.host
-        self.tracking_port = tracking_config.port
+        self.tracking_url = tracking_config.url
         self._session = requests.Session()
 
     def log(self, data: dict):
         req = self._session.post(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs",
+            f"https://{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -36,7 +38,7 @@ class Tracker:
 
     def get_logs(self):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs",
+            f"https://{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -44,7 +46,7 @@ class Tracker:
 
     def get_session_logs(self, session_id: str):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs/{session_id}",
+            f"https://{self.tracking_url}/api/tracking/logs/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -52,7 +54,7 @@ class Tracker:
 
     def update_session(self, data: dict):
         req = self._session.post(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session",
+            f"https://{self.tracking_url}/api/tracking/session",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -61,7 +63,7 @@ class Tracker:
 
     def get_session(self, session_id: str):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session/{session_id}",
+            f"https://{self.tracking_url}/api/tracking/session/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -69,7 +71,7 @@ class Tracker:
 
     def add_extras(self, message_id: int):
         req = self._session.patch(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session/{message_id}",
+            f"https://{self.tracking_url}/api/tracking/session/{message_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )


### PR DESCRIPTION
## LLMstudio tracker 1.0.5, LLMstudio proxy 1.0.4

### What was done in this PR:

- Possibility to pass an url as parameter to ProxyConfig() and TrackingConfig() instead of just host and port

### How it was tested:

- connected to local and hosted llmstudio-proxy and llmstudio-tracker using both methods (url and host,port)

### Additional notes:

- Any breaking changes? no
- Any new dependencies added? no
- Any performance improvements? no
