### PR TITLE
LLMstudio tracker 1.0.5, LLMstudio proxy 1.0.4, LLMstudio core 1.0.2

### DIFF
--- a/examples/core.py
+++ b/examples/core.py
@@ -11,20 +11,7 @@ def run_provider(provider, model, api_key, **kwargs):
     llm = LLMCore(provider=provider, api_key=api_key, **kwargs)
 
     latencies = {}
-    chat_request = {
-        "chat_input": "Hello, my name is Json",
-        "model": model,
-        "is_stream": False,
-        "retries": 0,
-        "parameters": {
-            "temperature": 0,
-            "max_tokens": 100,
-            "response_format": {"type": "json_object"},
-            "functions": None,
-        }
-    }
-
-
+    chat_request = build_chat_request(model, chat_input="Hello, my name is Jason Json", is_stream=False)
     
     import asyncio
     response_async = asyncio.run(llm.achat(**chat_request))
@@ -34,18 +21,7 @@ def run_provider(provider, model, api_key, **kwargs):
     # stream
     print("\nasync stream")
     async def async_stream():
-        chat_request = {
-            "chat_input": "Hello, my name is Json",
-            "model": model,
-            "is_stream": True,
-            "retries": 0,
-            "parameters": {
-                "temperature": 0,
-                "max_tokens": 100,
-                "response_format": {"type": "json_object"},
-                "functions": None,
-            }
-        }
+        chat_request = build_chat_request(model, chat_input="Hello, my name is Tom Json", is_stream=True)
         
         response_async = await llm.achat(**chat_request)
         async for p in response_async:
@@ -61,36 +37,14 @@ def run_provider(provider, model, api_key, **kwargs):
     
     
     print("# Now sync calls")
-    chat_request = {
-        "chat_input": "Hello, my name is Json",
-        "model": model,
-        "is_stream": False,
-        "retries": 0,
-        "parameters": {
-            "temperature": 0,
-            "max_tokens": 100,
-            "response_format": {"type": "json_object"},
-            "functions": None,
-        }
-    }
+    chat_request = build_chat_request(model, chat_input="Hello, my name is Alice Json", is_stream=False)
     
     response_sync = llm.chat(**chat_request)
     pprint(response_sync)
     latencies["sync (ms)"]= response_sync.metrics["latency_s"]*1000
 
     print("# Now sync calls streaming")
-    chat_request = {
-        "chat_input": "Hello, my name is Json",
-        "model": model,
-        "is_stream": True,
-        "retries": 0,
-        "parameters": {
-            "temperature": 0,
-            "max_tokens": 100,
-            "response_format": {"type": "json_object"},
-            "functions": None,
-        }
-    }
+    chat_request = build_chat_request(model, chat_input="Hello, my name is Mary Json", is_stream=True)
     
     response_sync_stream = llm.chat(**chat_request)
     for p in response_sync_stream:
@@ -101,12 +55,54 @@ def run_provider(provider, model, api_key, **kwargs):
             pprint(p)
             latencies["sync stream (ms)"]= p.metrics["latency_s"]*1000
 
-    print(f"\n\n###EPORT for {provider}, {model} ###")
+    print(f"\n\n###REPORT for <{provider}>, <{model}> ###")
     return latencies
+
+def build_chat_request(model: str, chat_input: str, is_stream: bool, max_tokens: int=1000):
+    if model == "o1-preview" or model == "o1-mini":
+        chat_request = {
+            "chat_input": chat_input,
+            "model": model,
+            "is_stream": is_stream,
+            "retries": 0,
+            "parameters": {
+                "max_completion_tokens": max_tokens
+            }
+        }
+    else:
+        chat_request = {
+            "chat_input": chat_input,
+            "model": model,
+            "is_stream": is_stream,
+            "retries": 0,
+            "parameters": {
+                "temperature": 0,
+                "max_tokens": max_tokens,
+                "response_format": {"type": "json_object"},
+                "functions": None,
+            }
+        }
+    return chat_request
+
+
+
 
 
 provider = "openai"
 model = "gpt-4o-mini"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, api_key=os.environ["OPENAI_API_KEY"])
+    pprint(latencies)
+
+    
+provider = "openai"
+model = "o1-preview"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, api_key=os.environ["OPENAI_API_KEY"])
+    pprint(latencies)
+    
+provider = "openai"
+model = "o1-mini"
 for _ in range(1):
     latencies = run_provider(provider=provider, model=model, api_key=os.environ["OPENAI_API_KEY"])
     pprint(latencies)
@@ -126,6 +122,24 @@ for _ in range(1):
                             api_version=os.environ["AZURE_API_VERSION"],
                             api_endpoint=os.environ["AZURE_API_ENDPOINT"])
     pprint(latencies)
+    
+provider = "azure"
+model = "o1-preview"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, 
+                            api_key=os.environ["AZURE_API_KEY"], 
+                            api_version=os.environ["AZURE_API_VERSION"],
+                            api_endpoint=os.environ["AZURE_API_ENDPOINT"])
+    pprint(latencies)
+    
+provider = "azure"
+model = "o1-mini"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, 
+                            api_key=os.environ["AZURE_API_KEY"], 
+                            api_version=os.environ["AZURE_API_VERSION"],
+                            api_endpoint=os.environ["AZURE_API_ENDPOINT"])
+    pprint(latencies)
 
 # provider = "azure"
 # model = "gpt-4o"
@@ -137,10 +151,10 @@ for _ in range(1):
 #     pprint(latencies)
 
 
-provider = "vertexai"
-model = "gemini-1.5-pro-latest"
-for _ in range(1):
-    latencies = run_provider(provider=provider, model=model, 
-                            api_key=os.environ["GOOGLE_API_KEY"], 
-                            )
-    pprint(latencies)
+# provider = "vertexai"
+# model = "gemini-1.5-pro-latest"
+# for _ in range(1):
+#     latencies = run_provider(provider=provider, model=model, 
+#                             api_key=os.environ["GOOGLE_API_KEY"], 
+#                             )
+#     pprint(latencies)

--- a/libs/core/llmstudio_core/config.yaml
+++ b/libs/core/llmstudio_core/config.yaml
@@ -204,6 +204,16 @@ providers:
     keys:
       - OPENAI_API_KEY
     models:
+      o1-preview:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.000015
+        output_token_cost: 0.000060
+      o1-mini:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.000003
+        output_token_cost: 0.000012
       gpt-4o-mini:
         mode: chat
         max_tokens: 128000
@@ -280,6 +290,16 @@ providers:
       - AZURE_API_ENDPOINT
       - AZURE_API_VERSION
     models:
+      o1-preview:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.0000165
+        output_token_cost: 0.000066
+      o1-mini:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.0000033
+        output_token_cost: 0.0000132
       gpt-4o-mini:
         mode: chat
         max_tokens: 128000

--- a/libs/core/llmstudio_core/utils.py
+++ b/libs/core/llmstudio_core/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, Field
 
 
 class OpenAIToolParameters(BaseModel):
@@ -30,9 +30,10 @@ class CostRange(BaseModel):
 
 class ModelConfig(BaseModel):
     mode: str
-    max_tokens: int
-    input_token_cost: Union[float, List[CostRange]]
-    output_token_cost: Union[float, List[CostRange]]
+    max_tokens: Optional[int] = Field(default=None, alias="max_completion_tokens")
+    max_completion_tokens: Optional[int] = None
+    input_token_cost: Union[float, List["CostRange"]]
+    output_token_cost: Union[float, List["CostRange"]]
 
 
 class ProviderConfig(BaseModel):

--- a/libs/core/llmstudio_core/utils.py
+++ b/libs/core/llmstudio_core/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import BaseModel, ValidationError, Field
+from pydantic import BaseModel, Field, ValidationError
 
 
 class OpenAIToolParameters(BaseModel):

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-core"
-version = "1.0.1"
+version = "1.0.2"
 description = "LLMStudio core capabilities for routing llm calls for any vendor. No proxy server required. For that use llmstudio[proxy]"
 authors = ["Cláudio Lemos <claudio.lemos@tensorops.ai>"]
 license = "MIT"

--- a/libs/proxy/llmstudio_proxy/provider.py
+++ b/libs/proxy/llmstudio_proxy/provider.py
@@ -18,26 +18,24 @@ class ProxyConfig(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if (self.host is None and self.port is None) and self.url is None:
-            raise ValueError(
-                "Either both 'host' and 'port' must be provided, or 'url' must be specified."
-            )
+        if self.url is None:
+            if self.host is not None and self.port is not None:
+                self.url = f"http://{self.host}:{self.port}"
+            else:
+                raise ValueError(
+                    "You must provide either both 'host' and 'port', or 'url'."
+                )
 
 
 class LLMProxyProvider(Provider):
     def __init__(self, provider: str, proxy_config: ProxyConfig):
         self.provider = provider
+        self.engine_url = proxy_config.url
 
-        self.engine_host = proxy_config.host
-        self.engine_port = proxy_config.port
-        if is_server_running(host=self.engine_host, port=self.engine_port):
-            print(
-                f"Connected to LLMStudio Proxy @ {self.engine_host}:{self.engine_port}"
-            )
+        if is_server_running(url=self.engine_url):
+            print(f"Connected to LLMStudio Proxy @ {self.engine_url}")
         else:
-            raise Exception(
-                f"LLMStudio Proxy is not running @ {self.engine_host}:{self.engine_port}"
-            )
+            raise Exception(f"LLMStudio Proxy is not running @ {self.engine_url}")
 
     @staticmethod
     def _provider_config_name():
@@ -53,7 +51,7 @@ class LLMProxyProvider(Provider):
         **kwargs,
     ) -> Union[ChatCompletion]:
         response = requests.post(
-            f"http://{self.engine_host}:{self.engine_port}/api/engine/chat/{self.provider}",
+            f"{self.engine_url}/api/engine/chat/{self.provider}",
             json={
                 "chat_input": chat_input,
                 "model": model,
@@ -109,7 +107,7 @@ class LLMProxyProvider(Provider):
     ):
         response = await asyncio.to_thread(
             requests.post,
-            f"http://{self.engine_host}:{self.engine_port}/api/engine/chat/{self.provider}",
+            f"{self.engine_url}/api/engine/chat/{self.provider}",
             json={
                 "chat_input": chat_input,
                 "model": model,
@@ -131,7 +129,7 @@ class LLMProxyProvider(Provider):
     ):
         response = await asyncio.to_thread(
             requests.post,
-            f"http://{self.engine_host}:{self.engine_port}/api/engine/chat/{self.provider}",
+            f"{self.engine_url}/api/engine/chat/{self.provider}",
             json={
                 "chat_input": chat_input,
                 "model": model,

--- a/libs/proxy/llmstudio_proxy/server.py
+++ b/libs/proxy/llmstudio_proxy/server.py
@@ -165,9 +165,9 @@ def run_proxy_app(started_event: Event):
         print(f"Error running LLMstudio Proxy: {e}")
 
 
-def is_server_running(host, port, path="/health"):
+def is_server_running(url, path="/health"):
     try:
-        response = requests.get(f"http://{host}:{port}{path}")
+        response = requests.get(f"{url}{path}")
         if response.status_code == 200 and response.json().get("status") == "healthy":
             return True
     except requests.ConnectionError:
@@ -176,7 +176,7 @@ def is_server_running(host, port, path="/health"):
 
 
 def start_server_component(host, port, run_func, server_name):
-    if not is_server_running(host, port):
+    if not is_server_running(url=f"http://{host}:{port}"):
         started_event = Event()
         thread = Thread(target=run_func, daemon=True, args=(started_event,))
         thread.start()

--- a/libs/proxy/pyproject.toml
+++ b/libs/proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-proxy"
-version = "1.0.3a0"
+version = "1.0.5a0"
 description = ""
 authors = ["Diogo Goncalves <diogo.goncalves@tensorops.ai>"]
 readme = "README.md"

--- a/libs/proxy/pyproject.toml
+++ b/libs/proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-proxy"
-version = "1.0.5a0"
+version = "1.0.4"
 description = ""
 authors = ["Diogo Goncalves <diogo.goncalves@tensorops.ai>"]
 readme = "README.md"

--- a/libs/proxy/pyproject.toml
+++ b/libs/proxy/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "llmstudio-proxy"
 version = "1.0.4"
-description = ""
-authors = ["Diogo Goncalves <diogo.goncalves@tensorops.ai>"]
+description = "LLMstudio Proxy is the module of LLMstudio that allows calling any LLM as a Service Provider in proxy server. By leveraging LLMstudio Proxy, you can have a centralized point for connecting to any provider running independently from your application."
+authors = ["Claudio Lemos <claudio.lemos@tensorops.ai>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/libs/tracker/llmstudio_tracker/server.py
+++ b/libs/tracker/llmstudio_tracker/server.py
@@ -66,9 +66,9 @@ def run_tracker_app(started_event: Event):
         print(f"Error running LLMstudio Tracking: {e}")
 
 
-def is_server_running(host, port, path="/health"):
+def is_server_running(url, path="/health"):
     try:
-        response = requests.get(f"http://{host}:{port}{path}")
+        response = requests.get(f"{url}{path}")
         if response.status_code == 200 and response.json().get("status") == "healthy":
             return True
     except requests.ConnectionError:
@@ -77,7 +77,7 @@ def is_server_running(host, port, path="/health"):
 
 
 def start_server_component(host, port, run_func, server_name):
-    if not is_server_running(host, port):
+    if not is_server_running(url=f"http://{host}:{port}"):
         started_event = Event()
         thread = Thread(target=run_func, daemon=True, args=(started_event,))
         thread.start()

--- a/libs/tracker/llmstudio_tracker/tracker.py
+++ b/libs/tracker/llmstudio_tracker/tracker.py
@@ -13,21 +13,23 @@ class TrackingConfig(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
-        if (self.host is None and self.port is None) and self.url is None:
-            raise ValueError(
-                "You must provide either both 'host' and 'port', or 'url', or 'database_uri'."
-            )
+        if self.url is None:
+            if self.host is not None and self.port is not None:
+                self.url = f"http://{self.host}:{self.port}"
+            else:
+                raise ValueError(
+                    "You must provide either both 'host' and 'port', or 'url'."
+                )
 
 
 class Tracker:
     def __init__(self, tracking_config: TrackingConfig):
-        self.tracking_host = tracking_config.host
-        self.tracking_port = tracking_config.port
+        self.tracking_url = tracking_config.url
         self._session = requests.Session()
 
     def log(self, data: dict):
         req = self._session.post(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs",
+            f"{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -36,7 +38,7 @@ class Tracker:
 
     def get_logs(self):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs",
+            f"{self.tracking_url}/api/tracking/logs",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -44,7 +46,7 @@ class Tracker:
 
     def get_session_logs(self, session_id: str):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/logs/{session_id}",
+            f"{self.tracking_url}/api/tracking/logs/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -52,7 +54,7 @@ class Tracker:
 
     def update_session(self, data: dict):
         req = self._session.post(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session",
+            f"{self.tracking_url}/api/tracking/session",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             data=json.dumps(data),
             timeout=100,
@@ -61,7 +63,7 @@ class Tracker:
 
     def get_session(self, session_id: str):
         req = self._session.get(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session/{session_id}",
+            f"{self.tracking_url}/api/tracking/session/{session_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )
@@ -69,7 +71,7 @@ class Tracker:
 
     def add_extras(self, message_id: int):
         req = self._session.patch(
-            f"http://{self.tracking_host}:{self.tracking_port}/api/tracking/session/{message_id}",
+            f"{self.tracking_url}/api/tracking/session/{message_id}",
             headers={"accept": "application/json", "Content-Type": "application/json"},
             timeout=100,
         )

--- a/libs/tracker/pyproject.toml
+++ b/libs/tracker/pyproject.toml
@@ -2,7 +2,7 @@
 name = "llmstudio-tracker"
 version = "1.0.5a0"
 description = "LLMstudio Tracker is the module of LLMstudio that allows monitoring and logging your LLM calls. By leveraging LLMstudio Tracker, users can gain insights on model performance and streamline development workflows with actionable analytics."
-authors = ["Diogo Goncalves <diogo.goncalves@tensorops.ai>"]
+authors = ["Claudio Lemos <claudio.lemos@tensorops.ai>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/libs/tracker/pyproject.toml
+++ b/libs/tracker/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-tracker"
-version = "1.0.4"
+version = "1.0.5a0"
 description = "LLMstudio Tracker is the module of LLMstudio that allows monitoring and logging your LLM calls. By leveraging LLMstudio Tracker, users can gain insights on model performance and streamline development workflows with actionable analytics."
 authors = ["Diogo Goncalves <diogo.goncalves@tensorops.ai>"]
 readme = "README.md"

--- a/libs/tracker/pyproject.toml
+++ b/libs/tracker/pyproject.toml
@@ -17,7 +17,7 @@ sqlalchemy-bigquery = "^1.12.0"
 google-cloud-bigquery-storage = "^2.27.0"
 
 [tool.poetry.scripts]
-llmstudio-proxy = "llmstudio_tracker.cli:main"
+llmstudio-tracker = "llmstudio_tracker.cli:main"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## LLMstudio tracker 1.0.5, LLMstudio proxy 1.0.4, LLMstudio core 1.0.2

### What was done in this PR:

- Possibility to pass an url as parameter to ProxyConfig() and TrackingConfig() instead of just host and port
- OpenAI new models available:
  - o1-preview, o1-mini

### How it was tested:

- connected to local and hosted llmstudio-proxy and llmstudio-tracker using both methods (url and host,port)

### Additional notes:

- Any breaking changes? no
- Any new dependencies added? no
- Any performance improvements? no

