### PR TITLE
feat: added support for o1-preview and o1-mini

### DIFF
--- a/examples/core.py
+++ b/examples/core.py
@@ -122,6 +122,24 @@ for _ in range(1):
                             api_version=os.environ["AZURE_API_VERSION"],
                             api_endpoint=os.environ["AZURE_API_ENDPOINT"])
     pprint(latencies)
+    
+provider = "azure"
+model = "o1-preview"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, 
+                            api_key=os.environ["AZURE_API_KEY"], 
+                            api_version=os.environ["AZURE_API_VERSION"],
+                            api_endpoint=os.environ["AZURE_API_ENDPOINT"])
+    pprint(latencies)
+    
+provider = "azure"
+model = "o1-mini"
+for _ in range(1):
+    latencies = run_provider(provider=provider, model=model, 
+                            api_key=os.environ["AZURE_API_KEY"], 
+                            api_version=os.environ["AZURE_API_VERSION"],
+                            api_endpoint=os.environ["AZURE_API_ENDPOINT"])
+    pprint(latencies)
 
 # provider = "azure"
 # model = "gpt-4o"

--- a/libs/core/llmstudio_core/config.yaml
+++ b/libs/core/llmstudio_core/config.yaml
@@ -290,6 +290,16 @@ providers:
       - AZURE_API_ENDPOINT
       - AZURE_API_VERSION
     models:
+      o1-preview:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.0000165
+        output_token_cost: 0.000066
+      o1-mini:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.0000033
+        output_token_cost: 0.0000132
       gpt-4o-mini:
         mode: chat
         max_tokens: 128000

--- a/libs/core/llmstudio_core/config.yaml
+++ b/libs/core/llmstudio_core/config.yaml
@@ -204,6 +204,16 @@ providers:
     keys:
       - OPENAI_API_KEY
     models:
+      o1-preview:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.000015
+        output_token_cost: 0.000060
+      o1-mini:
+        mode: chat
+        max_completion_tokens: 128000
+        input_token_cost: 0.000003
+        output_token_cost: 0.000012
       gpt-4o-mini:
         mode: chat
         max_tokens: 128000

--- a/libs/core/llmstudio_core/utils.py
+++ b/libs/core/llmstudio_core/utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, Field
 
 
 class OpenAIToolParameters(BaseModel):
@@ -30,9 +30,10 @@ class CostRange(BaseModel):
 
 class ModelConfig(BaseModel):
     mode: str
-    max_tokens: int
-    input_token_cost: Union[float, List[CostRange]]
-    output_token_cost: Union[float, List[CostRange]]
+    max_tokens: Optional[int] = Field(default=None, alias="max_completion_tokens")
+    max_completion_tokens: Optional[int] = None
+    input_token_cost: Union[float, List["CostRange"]]
+    output_token_cost: Union[float, List["CostRange"]]
 
 
 class ProviderConfig(BaseModel):


### PR DESCRIPTION
## LLMstudio Version X.X.X

### What was done in this PR:

- Added support for o1-preview and o1-mini models from OpenAI

### How it was tested:

- ```python examples/core.py``` which has examples of these models being used.

### Additional notes:

- Calculation of Costs is still not taking into account the reasoning tokens
