### PR TITLE
feat: added support for o3-mini and updated o1-mini prices

### DIFF
--- a/examples/core.py
+++ b/examples/core.py
@@ -97,7 +97,7 @@ Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots 
     return latencies
 
 def build_chat_request(model: str, chat_input: str, is_stream: bool, max_tokens: int=1000):
-    if model == "o1-preview" or model == "o1-mini":
+    if model.startswith(('o1', 'o3')):
         chat_request = {
             "chat_input": chat_input,
             "model": model,
@@ -132,7 +132,7 @@ def multiple_provider_runs(provider:str, model:str, num_runs:int, api_key:str, *
 
 # OpenAI
 multiple_provider_runs(provider="openai", model="gpt-4o-mini", api_key=os.environ["OPENAI_API_KEY"], num_runs=1)
-multiple_provider_runs(provider="openai", model="o1-mini", api_key=os.environ["OPENAI_API_KEY"], num_runs=1)
+multiple_provider_runs(provider="openai", model="o3-mini", api_key=os.environ["OPENAI_API_KEY"], num_runs=1)
 #multiple_provider_runs(provider="openai", model="o1-preview", api_key=os.environ["OPENAI_API_KEY"], num_runs=1)
 
 

--- a/libs/core/llmstudio_core/config.yaml
+++ b/libs/core/llmstudio_core/config.yaml
@@ -213,9 +213,15 @@ providers:
       o1-mini:
         mode: chat
         max_completion_tokens: 128000
-        input_token_cost: 0.000003
-        cached_token_cost: 0.0000015
-        output_token_cost: 0.000012
+        input_token_cost: 0.0000011
+        cached_token_cost: 0.00000055
+        output_token_cost: 0.0000044
+      o3-mini:
+        mode: chat
+        max_completion_tokens: 200000
+        input_token_cost: 0.0000011
+        cached_token_cost: 0.00000055
+        output_token_cost: 0.0000044
       gpt-4o-mini:
         mode: chat
         max_tokens: 128000

--- a/libs/core/tests/integration_tests/test_cache_and_reasoning_costs.py
+++ b/libs/core/tests/integration_tests/test_cache_and_reasoning_costs.py
@@ -124,7 +124,7 @@ def build_chat_request(
 
 # Fixture for provider-model pairs
 @pytest.fixture(
-    scope="module", params=[("openai", "gpt-4o-mini"), ("openai", "o3-mini")]
+    scope="module", params=[("openai", "gpt-4o-mini"), ("openai", "o1-mini")]
 )
 def provider_model(request):
     return request.param
@@ -176,7 +176,7 @@ def usage_when_max_tokens_reached():
     """
     Usefull to test handling of Usage in other finish_reason scenarios
     """
-    provider, model = ("openai", "o3-mini")
+    provider, model = ("openai", "o1-mini")
     api_key = os.environ["OPENAI_API_KEY"]
 
     llm = LLMCore(provider=provider, api_key=api_key)


### PR DESCRIPTION
## LLMstudio Version X.X.X

### What was done in this PR:

- Added o3-mini to config and updated o1-mini prices
- Updated some integration tests to support o3-mini

### How it was tested:

- Ran `python examples/core.py` where o3-mini is being used
- Integration tests passed, some of which now use o3-mini instead of o1-mini
