### PR TITLE
Fix bump versions for py pi

### DIFF
--- a/libs/llmstudio/pyproject.toml
+++ b/libs/llmstudio/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio"
-version = "1.0.3"
+version = "1.0.4"
 description = "Prompt Perfection at Your Fingertips"
 authors = ["Cláudio Lemos <claudio@tensorops.ai>"]
 license = "MIT"

--- a/libs/proxy/pyproject.toml
+++ b/libs/proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-proxy"
-version = "1.0.5"
+version = "1.0.6"
 description = "LLMstudio Proxy is the module of LLMstudio that allows calling any LLM as a Service Provider in proxy server. By leveraging LLMstudio Proxy, you can have a centralized point for connecting to any provider running independently from your application."
 authors = ["Claudio Lemos <claudio.lemos@tensorops.ai>"]
 readme = "README.md"

--- a/libs/tracker/pyproject.toml
+++ b/libs/tracker/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llmstudio-tracker"
-version = "1.1.0"
+version = "1.1.1"
 description = "LLMstudio Tracker is the module of LLMstudio that allows monitoring and logging your LLM calls. By leveraging LLMstudio Tracker, users can gain insights on model performance and streamline development workflows with actionable analytics."
 authors = ["Claudio Lemos <claudio.lemos@tensorops.ai>"]
 readme = "README.md"


### PR DESCRIPTION
## Bump versions for PyPI
* llmstudio: 1.0.4
* proxy: 1.0.6
* tracker: 1.1.1
